### PR TITLE
Fixed - printer attempting to print past X=10 when using entire 250mm of print bed.

### DIFF
--- a/Marlin_ER20/Marlin/Configuration.h
+++ b/Marlin_ER20/Marlin/Configuration.h
@@ -1093,7 +1093,7 @@
 #define Y_BED_SIZE 226 
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
-#define X_MIN_POS  10
+#define X_MIN_POS  0
 #define Y_MIN_POS  -8
 #define Z_MIN_POS 0
 #define X_MAX_POS (X_BED_SIZE + X_MIN_POS)


### PR DESCRIPTION
When printing parts of size > 240mm, this version of the firmware will attempt to compress the entire left 10mm of the part into one line. Causing all sorts of odd behavior. Setting this to 0 solves this issue.

The leftmost side (10mm) of the printable space in the slicer will ruin a part with this version of the firmware. This is because the gcode wants the printer to go to an absolute position of {0-9.999}, but the printer cannot go any further than x=10. This should never be a positive number, but it makes sense for it to be a negative one. In reality, this position should be x=0, especially for a printer with no physical endstops.

Specifically, this is for the Eryone ER20.